### PR TITLE
relax mariaex and postrex requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,8 +30,8 @@ defmodule Ectophile.Mixfile do
 
   defp deps do
     [{:ecto, "~> 1.0"},
-     {:postgrex, "~> 0.9.1", optional: true},
-     {:mariaex, "~> 0.4.1", optional: true},
+     {:postgrex, ">= 0.9.1", optional: true},
+     {:mariaex, ">= 0.4.1", optional: true},
      {:poison, "~> 1.0", optional: true},
      {:plug, "~> 1.0", only: :test},
      {:ex_doc, "~> 0.7", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,11 @@
-%{"decimal": {:hex, :decimal, "1.1.0"},
-  "earmark": {:hex, :earmark, "0.1.17"},
-  "ecto": {:hex, :ecto, "1.0.2"},
-  "ex_doc": {:hex, :ex_doc, "0.8.4"},
+%{"connection": {:hex, :connection, "1.0.2"},
+  "decimal": {:hex, :decimal, "1.1.1"},
+  "earmark": {:hex, :earmark, "0.2.0"},
+  "ecto": {:hex, :ecto, "1.1.1"},
+  "ex_doc": {:hex, :ex_doc, "0.11.2"},
   "inch_ex": {:hex, :inch_ex, "0.4.0"},
-  "mariaex": {:hex, :mariaex, "0.4.3"},
-  "plug": {:hex, :plug, "1.0.0"},
+  "mariaex": {:hex, :mariaex, "0.6.1"},
+  "plug": {:hex, :plug, "1.0.3"},
   "poison": {:hex, :poison, "1.5.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.9.1"}}
+  "postgrex": {:hex, :postgrex, "0.10.0"}}


### PR DESCRIPTION
I wanted to update postgrex to "0.10.0" but had to relax the constraints. This produces a couple deprecation warnings:

```
warning: before_insert is deprecated
    test/ectophile_test.exs:11: EctophileTest.User (module)
warning: before_update is deprecated
    test/ectophile_test.exs:11: EctophileTest.User (module)
warning: before_update is deprecated
    test/ectophile_test.exs:11: EctophileTest.User (module)
warning: after_delete is deprecated
    test/ectophile_test.exs:11: EctophileTest.User (module)
```
