### PR TITLE
fix build_priv_path

### DIFF
--- a/lib/ectophile.ex
+++ b/lib/ectophile.ex
@@ -98,8 +98,8 @@ defmodule Ectophile do
     Path.join(["priv/static", upload_path, file_id])
   end
 
-  def build_priv_path(filepath) do
-    Application.app_dir(otp_app(), filepath)
+  def build_priv_path(upload_path) do
+    Application.app_dir(otp_app(), Path.join(["priv/static", upload_path]))
   end
 
   def build_priv_path(upload_path, file_id, filename) do


### PR DESCRIPTION
when Mix.Project.config[:build_embedded] == true
ectophile failed to copy because the path wasn't created properly in ensure_upload_paths_exist
